### PR TITLE
Add `to_input_param` to generate input parameter ids

### DIFF
--- a/zatsu_cwl_generator.d
+++ b/zatsu_cwl_generator.d
@@ -128,7 +128,7 @@ do
     }
     else
     {
-        return value.tr(".", "_");
+        return value.tr(".-", "_");
     }
 }
 
@@ -138,6 +138,9 @@ unittest {
     assert("3.14".to_input_param == "_3_14");
     assert("foobar.txt".to_input_param == "foobar_txt");
     assert("value".to_input_param == "value");
+
+    // For #5
+    assert("this-file-is.txt".to_input_param == "this_file_is_txt");
 }
 
 auto guess_type(string option, string value)


### PR DESCRIPTION
It solves #5 and #7.

To solve it, I added `to_input_param` function that returns an input parameter `id` from a given argument of the command line.

Note:
- I use [the D Style](https://dlang.org/dstyle.html) for formatting. The other part of the code does not use this style but it will be fixed in other PR.
- I added [ddoc comments](https://dlang.org/spec/ddoc.html) for `to_input_param` and its unittest. By using `dmd -Dddoc zatsu_cwl_generater.d`, we can generate the document with examples in `doc` directory.